### PR TITLE
Update to v0.7.9: Add brand colors for Flathub and small UI improvement

### DIFF
--- a/com.odnoyko.valot.json
+++ b/com.odnoyko.valot.json
@@ -66,7 +66,7 @@
                 {
                     "type" : "git",
                     "url" : "https://gitlab.com/Valo27/valot.git",
-                    "tag" : "v0.7.8"
+                    "tag" : "v0.7.9"
                 }
             ]
         }


### PR DESCRIPTION
In last version Brand colors missing, now its update.  Selected best for this Icon color for Both themes.

Another exept small UI change not updated. 

note: New icon in work, current icon is temporaly 