### PR TITLE
Update runtime to 50

### DIFF
--- a/com.odnoyko.valot.json
+++ b/com.odnoyko.valot.json
@@ -1,7 +1,7 @@
 {
     "id" : "com.odnoyko.valot",
     "runtime" : "org.gnome.Platform",
-    "runtime-version" : "49",
+    "runtime-version" : "50",
     "sdk" : "org.gnome.Sdk",
     "sdk-extensions" : [
         "org.freedesktop.Sdk.Extension.node20",
@@ -25,13 +25,8 @@
     "cleanup" : [
         "/include",
         "/lib/pkgconfig",
-        "/man",
-        "/share/doc",
-        "/share/gtk-doc",
-        "/share/man",
-        "/share/pkgconfig",
-        "*.la",
-        "*.a"
+        "/share/gir-1.0",
+        "/share/vala"
     ],
     "modules" : [
         "shared-modules/intltool/intltool-0.51.json",
@@ -54,7 +49,8 @@
                 {
                     "type" : "git",
                     "url" : "https://gitlab.com/Valo27/valot.git",
-                    "tag" : "v0.9.3"
+                    "tag" : "v0.9.3",
+                    "commit" : "59a67451364b5277dc45202011121ed4c49fc800"
                 }
             ]
         }


### PR DESCRIPTION
- Update the runtime version to 50
- Drop ineffective cleanup commands
- Improve cleanup commands to reduce the Flatpak size
- Add missing commit ID

The installed size reduced from 8.5 MB to 5.5 MB